### PR TITLE
set dst/lib as linker rpath for rbczmq_ext

### DIFF
--- a/ext/rbczmq/extconf.rb
+++ b/ext/rbczmq/extconf.rb
@@ -143,7 +143,8 @@ fail "Error compiling and linking libczmq" unless have_library("czmq")
 
 $defs << "-pedantic"
 
-$CFLAGS << ' -Wall -funroll-loops'
-$CFLAGS << ' -Wextra -O0 -ggdb3' if ENV['DEBUG']
+$CFLAGS  << ' -Wall -funroll-loops'
+$CFLAGS  << ' -Wextra -O0 -ggdb3' if ENV['DEBUG']
+$LDFLAGS << " -Wl,-rpath,ext/rbczmq/dst/lib/"
 
 create_makefile('rbczmq_ext')


### PR DESCRIPTION
Setting the linker -rpath option to ext/rbczmq/dst/lib/ will allow
"rake" to successfully compile and run the tests.

Using a relative path means this will not work in the following
cases:

1. When the path can be resolved from the current working directory
2. After gem install; once the libraries have been installed to the gem
   path.

Would it be possible to compute an absolute path within the GEM PATH
where the dst/lib will end up?

refs #39