### PR TITLE
Fix Bundler related error on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ notifications:
     - lourens@methodmissing.com
     - matt.connolly@me.com
 before_install:
+  - gem update bundler
   - if [[ $(ruby -v) =~ rubinius ]]; then travis_retry gem install rubysl; fi; gem list; true
 matrix:
   allow_failures:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ffi2-generators (0.1.1)
-    json (1.8.1)
+    json (1.8.3)
     minitest (5.5.0)
     rake (10.4.2)
     rake-compiler (0.8.3)


### PR DESCRIPTION
The following error is caused by old Bundler.

https://travis-ci.org/methodmissing/rbczmq/jobs/128316516#L203

``` text
$ bundle install --quiet
NoMethodError: undefined method `spec' for nil:NilClass
```
