### PR TITLE
Ensure linking bundled libraries

### DIFF
--- a/ext/rbczmq/extconf.rb
+++ b/ext/rbczmq/extconf.rb
@@ -147,7 +147,7 @@ $INCFLAGS << " -I#{libsodium_include_path}" if find_header("sodidum.h", libsodiu
 $INCFLAGS << " -I#{zmq_include_path}" if find_header("zmq.h", zmq_include_path)
 $INCFLAGS << " -I#{czmq_include_path}" if find_header("czmq.h", czmq_include_path)
 
-$LIBPATH << libs_path.to_s
+$DEFLIBPATH.unshift(libs_path.to_s)
 
 # Special case to prevent Rubinius compile from linking system libzmq if present
 if defined?(RUBY_ENGINE) && RUBY_ENGINE =~ /rbx/ && RUBY_PLATFORM =~ /linux/


### PR DESCRIPTION
If dependency libraries (czmq, libsodium and zeromq) are already
installed in system and they exist in Ruby's library path, rbczmq uses
headers of bundled libraries and shared objects of system
libraries. Because link command generated by mkmf.rb uses `$DEFLIBPATH |
$LIBPATH` as library search path. `$DEFLIBPATH` includes Ruby's library
path. If dependency libraries already exist in Ruby's library path, they
are used instead of bundled libraries.

It causes segmentation fault.
